### PR TITLE
Add default grid color option to match dark and light color themes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It's intended to be used alongside [DataviewJS](https://blacksmithgu.github.io/o
 const calendarData = { 
 	entries: [], // Populated in the DataviewJS loop below
 	year: 2022,  // (optional) Defaults to current year
+  gridColor: "#2a2a2a", // (optional) Defaults to "#ffffff"
 	colors: {    // (optional) Defaults to green
 	  blue:        ["#8cb9ff","#69a3ff","#428bff","#1872ff","#0058e2"], // first entry is considered default if supplied
 	  green:       ["#c6e48b","#7bc96f","#49af5d","#2e8840","#196127"],

--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,7 @@ import { Plugin } from 'obsidian';
 interface HeatmapCalendarSettings {
 	year: number;
 	defaultEntryIntensity: number;
+	defaultGridColor: string;
 	colors: {
 		default: Array<string>;
 	};
@@ -17,6 +18,7 @@ interface HeatmapCalendarSettings {
 const DEFAULT_SETTINGS: HeatmapCalendarSettings = {
 	year: new Date().getUTCFullYear(),
 	defaultEntryIntensity: 4,
+	defaultGridColor: "#ffffff",
 	colors: {
 		default: ["#c6e48b", "#7bc96f", "#49af5d", "#2e8840", "#196127"]
 	},
@@ -32,6 +34,7 @@ interface Entry {
 
 interface CalendarData {
 	year?: number;
+	gridColor: string;
 	colors?: {
 		[index: string | number]: {
 			[index: number]: string;
@@ -70,6 +73,7 @@ export default class HeatmapCalendar extends Plugin {
 			const year = calendarData.year ?? this.settings.year
 			const colors = calendarData.colors ?? this.settings.colors
 			const calEntries = calendarData.entries ?? this.settings.entries
+			const gridColor = calendarData.gridColor ?? this.settings.defaultGridColor
 
 			const intensities: Array<number> = []
 			calEntries.forEach(e => {
@@ -130,7 +134,7 @@ export default class HeatmapCalendar extends Plugin {
 					}
 					boxes.push({ backgroundColor: background_color, content: content })
 				} else {
-					boxes.push({ backgroundColor: "" })
+					boxes.push({ backgroundColor: gridColor })
 				}
 			}
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "heatmap-calendar",
 	"name": "Heatmap Calendar",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"minAppVersion": "0.12.0",
 	"description": "Activity Year Overview for DataviewJS, Github style – Track Goals, Progress, Habits, Tasks, Exercise, Finances, \"Dont Break the Chain\" etc.",
 	"author": "Richard Slettevoll",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "heatmap-calendar",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "heatmap-calendar",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "Apache-2.0 License",
 			"devDependencies": {
 				"@types/node": "^16.11.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "heatmap-calendar",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "heatmap-calendar",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Activity Heatmap Calendar Plugin for Obsidian",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This adds the ability to specify a default gridColor for cells without matching data so the styling can better match themes with light or dark colors. Attempts to address #6.

```dataviewjs
const calendarData = { 
	entries: [],
	year: 2022,
        gridColor: "#2a2a2a", // (optional) Defaults to "#ffffff"
}
```