### PR TITLE
Issue/57

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -81,7 +81,7 @@ export default class HeatmapCalendar extends Plugin {
 
 			this.removeHtmlElementsNotInYear(calendarData.entries, year)
 
-			const calEntries = calendarData.entries.filter(e => new Date(e.date).getFullYear() + 1 === year) ?? this.settings.entries
+			const calEntries = calendarData.entries.filter(e => new Date(e.date + "T00:00").getFullYear() === year) ?? this.settings.entries
 
 			const showCurrentDayBorder = calendarData.showCurrentDayBorder ?? this.settings.showCurrentDayBorder
 

--- a/main.ts
+++ b/main.ts
@@ -81,7 +81,7 @@ export default class HeatmapCalendar extends Plugin {
 
 			this.removeHtmlElementsNotInYear(calendarData.entries, year)
 
-			const calEntries = calendarData.entries.filter(e => new Date(e.date).getFullYear() === year) ?? this.settings.entries
+			const calEntries = calendarData.entries.filter(e => new Date(e.date).getFullYear() + 1 === year) ?? this.settings.entries
 
 			const showCurrentDayBorder = calendarData.showCurrentDayBorder ?? this.settings.showCurrentDayBorder
 


### PR DESCRIPTION
Adding T00:00 should force the date to account for a difference in time zones on New Year's Day. This will force it to be the correct year instead of sometimes making the near the prior one. Fix for Issue #57