### PR TITLE
The plugin should give priority to manually-set scale when mapping intensity

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -102,7 +102,7 @@ export default class HeatmapCalendar extends Plugin {
 				const colorIntensities = colors[e.color] ?? colors[Object.keys(colors)[0]]
 				const numOfColorIntensities = Object.keys(colorIntensities).length
 
-				if(minimumIntensity === maximumIntensity) newEntry.intensity = minimumIntensity
+				if(intensityScaleStart === intensityScaleEnd) newEntry.intensity = minimumIntensity
 				else newEntry.intensity = Math.round(this.map(newEntry.intensity, intensityScaleStart, intensityScaleEnd, 1, numOfColorIntensities))
 	
 				mappedEntries[this.getHowManyDaysIntoYear(new Date(e.date))] = newEntry


### PR DESCRIPTION
So, I struggled for an hour to understand why this plugin failed to map my "mindfulness:: 10" entries with the correct shade of color. Then I discovered that it happened that, by coincidence, I meditated 10 minutes for the first 3 days of the year. In this case, the plugin check `minimumIntensity === maximumIntensity` (the actual minimum and maximum values of my entries), and because they are the same,  it completely ignores my scale (that goes from 1 to 60) and try to set the intensity index 10 (that doesn't exist).

I find this behavior confusing, especially at the beginning of the year (when there are just a couple of entries and, therefore, it is very likely that `minimumIntensity === maximumIntensity` by accident).

A better behavior should be to always map the intensity between `intensityScaleStart` and `intensityScaleEnd` if the user set those values. If not, they will fall back to `minimumIntensity === maximumIntensity` and, therefore, the old behavior is preserved. So I think we can have our cake and eat it.

This PR address this.

