### PR TITLE
Wrap the entry content in a `span` element

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -200,13 +200,18 @@ export default class HeatmapCalendar extends Plugin {
 			})
 
 			boxes.forEach(e => {
-				createEl("li", {
-					text: e.content,
+				const entry = createEl("li", {
 					attr: {
 						...e.backgroundColor && { style: `background-color: ${e.backgroundColor};`, },
 					},
 					cls: e.classNames,
 					parent: heatmapCalendarBoxesUl,
+				})
+
+				createSpan({
+					cls: "heatmap-calendar-content",
+					parent: entry,
+					text: e.content,
 				})
 			})
 


### PR DESCRIPTION
By wrapping the entry content in a `span` element, we can allow more versatile custom styling of the content. See example below:

https://user-images.githubusercontent.com/1847066/221376643-fbc8ffd1-bd1d-4676-9815-ab80e91082e2.mov

