### PR TITLE
Add ability to define global color schemes via the Settings panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,28 @@ You don't need to supply any colors, the calendar uses green by default, just li
 If you do supply colors to *calendarData.colors*, the first index will be considered the new default color.
 
 Add a custom color to each entry by specifying the name you gave the color in calendarData.colors.
-You can even use multiple colors in the same calendar, just use different colors for different entries.  
-   
+You can even use multiple colors in the same calendar, just use different colors for different entries.
+
 The color schemes used in the examples were created at [leonardocolor.io](https://leonardocolor.io).
+
+### Adding global colors:
+
+You can also add a color scheme which will be available everywhere via the Settings panel.
+
+In order to do so go to `Obsidian Settings > Heatmap Calendar`, you will see a list of available colors, and you can add your own. You must specify a “Color name” by which you will reference it in your render call, and provide a valid array of colors.
+
+When you do so, you can now reference your scheme everywhere by passing your name to the `colors` option. For example, let's say you have defined a new color called `githubGreen`. Now, in your code, you can reference it like so:
+
+~~~javascript
+\```dataviewjs
+const calendarData = {
+	color: "githubGreen",
+	entries: [], // <- your entries
+}
+
+renderHeatmapCalendar(this.container, calendarData)
+```
+~~~
 
 &nbsp;
 

--- a/main.css
+++ b/main.css
@@ -1,0 +1,8 @@
+/* settings/settings.css */
+.heatmap-calendar-settings-colors__color-box {
+  width: 10px;
+  height: 10px;
+  display: inline-block;
+  margin: 0 5px;
+}
+/*# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsic2V0dGluZ3Mvc2V0dGluZ3MuY3NzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyIuaGVhdG1hcC1jYWxlbmRhci1zZXR0aW5ncy1jb2xvcnNfX2NvbG9yLWJveCB7XG4gICAgd2lkdGg6IDEwcHg7XG4gICAgaGVpZ2h0OiAxMHB4O1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBtYXJnaW46IDAgNXB4O1xufVxuIl0sCiAgIm1hcHBpbmdzIjogIjtBQUFBO0FBQ0k7QUFDQTtBQUNBO0FBQ0E7QUFBQTsiLAogICJuYW1lcyI6IFtdCn0K */

--- a/main.ts
+++ b/main.ts
@@ -1,18 +1,24 @@
 import { Plugin, } from 'obsidian'
+import HeatmapCalendarSettingsTab from "settings"
 
 interface CalendarData {
 	year: number
 	colors: {
-		[index: string | number]: {
-			[index: number]: string
-		}
-	}
+		[index: string | number]: string[]
+	} | string
 	entries: Entry[]
 	showCurrentDayBorder: boolean
 	defaultEntryIntensity: number
 	intensityScaleStart: number
 	intensityScaleEnd: number
 }
+
+interface CalendarSettings extends CalendarData {
+	colors: {
+		[index: string | number]: string[]
+	}
+}
+
 interface Entry {
 	date: string
 	intensity?: number
@@ -32,7 +38,7 @@ const DEFAULT_SETTINGS: CalendarData = {
 }
 export default class HeatmapCalendar extends Plugin {
 
-	settings: CalendarData
+	settings: CalendarSettings
 
 	/**
 	 * Returns a number representing how many days into the year the supplied date is. 
@@ -74,11 +80,17 @@ export default class HeatmapCalendar extends Plugin {
 
 		await this.loadSettings()
 
+		this.addSettingTab(new HeatmapCalendarSettingsTab(this.app, this))
+
 		//@ts-ignore
 		window.renderHeatmapCalendar = (el: HTMLElement, calendarData: CalendarData): void => {
 
 			const year = calendarData.year ?? this.settings.year
-			const colors = calendarData.colors ?? this.settings.colors
+			const colors = typeof calendarData.colors === "string"
+				? this.settings.colors[calendarData.colors]
+					? { [calendarData.colors]: this.settings.colors[calendarData.colors], }
+					: this.settings.colors
+				: calendarData.colors ?? this.settings.colors
 
 			this.removeHtmlElementsNotInYear(calendarData.entries, year)
 
@@ -100,7 +112,10 @@ export default class HeatmapCalendar extends Plugin {
 					intensity: defaultEntryIntensity,
 					...e,
 				}
-				const colorIntensities = colors[e.color] ?? colors[Object.keys(colors)[0]]
+				const colorIntensities = typeof colors === "string"
+					? this.settings.colors[colors]
+					: colors[e.color] ?? colors[Object.keys(colors)[0]]
+
 				const numOfColorIntensities = Object.keys(colorIntensities).length
 
 				if(minimumIntensity === maximumIntensity && intensityScaleStart === intensityScaleEnd) newEntry.intensity = numOfColorIntensities
@@ -204,6 +219,7 @@ export default class HeatmapCalendar extends Plugin {
 					text: e.content,
 					attr: {
 						...e.backgroundColor && { style: `background-color: ${e.backgroundColor};`, },
+						...e.date && { "data-date": e.date, },
 					},
 					cls: e.classNames,
 					parent: heatmapCalendarBoxesUl,
@@ -218,6 +234,7 @@ export default class HeatmapCalendar extends Plugin {
 	}
 
 	async loadSettings() {
+		console.log( "heyoh", await this.loadData() );
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData())
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "heatmap-calendar",
-	"version": "0.6.0",
+	"version": "0.5.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "heatmap-calendar",
-			"version": "0.6.0",
+			"version": "0.5.4",
 			"license": "Apache-2.0 License",
 			"devDependencies": {
 				"@types/node": "^18.0.5",

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,162 @@
+import HeatmapCalendar from "main"
+import { App, PluginSettingTab, setIcon, Setting, } from "obsidian"
+
+export default class HeatmapCalendarSettingsTab extends PluginSettingTab {
+	plugin: HeatmapCalendar
+
+	constructor(app: App, plugin: HeatmapCalendar) {
+		super(app, plugin)
+		this.plugin = plugin
+	}
+
+	private async addColorMap(color: { key: string, value: string }) {
+		const isValid = { key: true, value: true, }
+
+		if (!color.key) isValid.key = false
+
+		const validatedArray = this.validateColorInput(color.value)
+
+		if (!validatedArray) isValid.value = false
+
+		if (isValid.key && isValid.value) {
+			this.plugin.settings.colors[color.key] = validatedArray as string[]
+
+			await this.plugin.saveSettings()
+
+			this.display()
+		}
+
+		return isValid
+	}
+
+	private async deleteColorMap(key: keyof typeof this.plugin.settings.colors) {
+		delete this.plugin.settings.colors[key]
+
+		await this.plugin.saveSettings()
+
+		this.display()
+	}
+
+	private displayColorSettings() {
+		const { containerEl, } = this
+
+		containerEl.createEl("h3", { text: "Colors", })
+		this.displayColorHelp(containerEl)
+
+		for (const [key, colors,] of Object.entries(this.plugin.settings.colors)) {
+			const colorEntryContainer = containerEl.createDiv({
+				cls: "heatmap-calendar-settings-colors__container",
+			})
+
+			const colorDataContainer = colorEntryContainer.createDiv({
+				cls: "heatmap-calendar-settings-colors__data-container",
+			})
+
+			colorDataContainer.createEl("h4", { text: key, })
+
+			const colorRow = colorDataContainer.createDiv({ cls: "heatmap-calendar-settings-colors__row", })
+
+			const colorsContainer = colorRow.createDiv({ cls: "heatmap-calendar-settings-colors__color-container", })
+
+			for (const color of colors) {
+				colorsContainer.createEl("div", {
+					cls: "heatmap-calendar-settings-colors__color-box",
+					attr: {
+						style: `background-color: ${color}`,
+					},
+				})
+
+				colorsContainer.createEl("pre", {
+					cls: "heatmap-calendar-settings-colors__color-name",
+					text: color,
+				})
+			}
+
+			if (key !== "default") {
+				const deleteColorButton = colorEntryContainer.createEl("button", {
+					cls: "mod-warning heatmap-calendar-settings-colors__delete",
+				})
+
+				setIcon(deleteColorButton, "trash")
+
+				deleteColorButton.addEventListener("click", () => this.deleteColorMap(key))
+			}
+		}
+
+		this.displayColorInput(containerEl)
+	}
+
+	private displayColorInput(parent: HTMLElement) {
+		const inputContainer = parent.createDiv({ cls: "heatmap-calendar-settings-colors__new-color-input-container", })
+
+		const colorNameInput = inputContainer.createEl("input", {
+			cls: "heatmap-calendar-settings-colors__new-color-input-name",
+			attr: { placeholder: "Color name", type: "text", },
+		})
+
+		const colorValueInput = inputContainer.createEl("input", {
+			cls: "heatmap-calendar-settings-colors__new-color-input-value",
+			attr: { placeholder: "Colors array", type: "text", },
+		})
+
+		const addColorButton = inputContainer.createEl("button", {
+			cls: "mod-cta heatmap-calendar-settings-colors__new-color-button",
+		})
+
+		setIcon(addColorButton, "plus")
+
+		addColorButton.addEventListener("click", async () => {
+			const isValid = await this.addColorMap({
+				key: colorNameInput.value,
+				value: colorValueInput.value,
+			})
+
+			this.reportInputValidity(colorNameInput, isValid.key, "Please input a name for your color")
+			this.reportInputValidity(colorValueInput, isValid.value, "Color is not a valid JSON array of colors")
+		})
+	}
+
+	private displayColorHelp(parent: HTMLElement) {
+		parent.createEl("p", {
+			text: "Add lists of colors which will be globally available on your heatmaps.",
+		})
+		parent.createEl("p", {
+			text: "You can use those colors by referencing their name in your heatmap render settings.",
+		})
+	}
+
+	private reportInputValidity(input: HTMLInputElement, isValid: boolean, msg: string) {
+		if (!isValid) {
+			input.classList.add("has-error")
+			input.setCustomValidity(msg)
+		} else input.setCustomValidity("")
+
+		input.reportValidity()
+	}
+
+	private validateColorInput(value: string) {
+		const colorRegex = /^(#[0-9a-f]{3,6}|rgba?\(\s*\d+%?\s*,\s*\d+%?\s*,\s*\d+%?\s*(,\s*\d+(\.\d+)?%?)?\s*\))$/i;
+
+		try {
+			const data: string[] = JSON.parse(value)
+
+			if (!Array.isArray(data)) return false
+
+			return data.every(color => colorRegex.test(color)) ? data : false
+		} catch (e) {
+			return false
+		}
+	}
+
+	display() {
+		const { containerEl, } = this
+
+		containerEl.empty()
+
+		containerEl.createEl("h2", { text: "Heatmap Calendar Settings", })
+
+		this.displayColorSettings()
+
+		console.log( "settings", this.plugin.settings )
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,5 @@
 /* Obsidian/DataviewJS Github inspired calendar by Richard Slettevoll - https://richard.sl/ */
+
 .heatmap-calendar-graph>* {
   padding: 0px;
   margin: 0px;
@@ -82,4 +83,50 @@
 
 .heatmap-calendar-boxes .today {
   border: solid 1px rgb(61, 61, 61);
+}
+
+/* Settings */
+
+.heatmap-calendar-settings-colors__color-box {
+    width: 10px;
+    height: 10px;
+    display: inline-block;
+    margin: 0 5px;
+}
+
+.heatmap-calendar-settings-colors__color-box:first-child {
+	margin-left: 0;
+}
+
+.heatmap-calendar-settings-colors__color-name {
+    display: inline-block;
+}
+
+.heatmap-calendar-settings-colors__container {
+	align-items: center;
+	border-top: 1px solid var(--background-modifier-border);
+	display: flex;
+	justify-content: space-between;
+	padding: 0.5em 0;
+}
+
+.heatmap-calendar-settings-colors__container h4 {
+	margin: 0.5em 0;
+}
+
+.heatmap-calendar-settings-colors__new-color-input-container {
+	display: flex;
+	justify-content: space-between;
+}
+
+.heatmap-calendar-settings-colors__new-color-input-container input {
+	margin-right: 1em;
+}
+
+.heatmap-calendar-settings-colors__new-color-input-container input {
+	margin-right: 1em;
+}
+
+.heatmap-calendar-settings-colors__new-color-input-value {
+	flex-grow: 1;
 }


### PR DESCRIPTION
This PR adds the ability for the users to add their custom color schemes via the Settings panel. These color schemes are available globally and can be referenced by their user-defined `key`.

The UI could definitely use some improvement, but for now I think it's better than nothing and can be iterated upon.

![Screenshot 2023-02-25 at 23 31 35](https://user-images.githubusercontent.com/1847066/221382536-08d015e5-a5b9-4ac5-8093-fc6efb10b4dc.png)

The users can add custom color schemes by adding a `key` and a valid array. They can also delete their custom schemes, but not the default one. Inputs are validated for these rules:

1. Must have a name
2. Must provide a valid color array

Documentation is included.

## Testing instructions

### Positive case

1. Open `Obsidian Settings > Heatmap Calendar`
2. Make sure the `default` color scheme is available there and can't be deleted.
3. Input a color scheme name.
4. Input a color array.
5. Click the plus button.
6. Make sure the new color scheme appears in the UI.
7. Try using the color scheme in your data as mentioned in the docs.

### Negative case

1. Repeat steps 1–2 above.
2. Click on the plus button.
3. A validation error should appear on the colors array input.
4. Try to input invalid JSON or an array of strings which are not valid CSS colors.
5. A validation error should appear on the colors array input.
6. Input a valid array.
7. Click on the plus button.
8. A validation error should appear on the colors name input.