### PR TITLE
fix #75: EXAMPLE_VAULT cells are not showing

### DIFF
--- a/EXAMPLE_VAULT/Overview extended.md
+++ b/EXAMPLE_VAULT/Overview extended.md
@@ -54,6 +54,7 @@ renderHeatmapCalendar(this.container, calendarData)
 dv.span("**💸 Money Spent 💸**")
 
 const calendarData = {
+    year: 2022,
     entries: [],
 }
 
@@ -74,6 +75,7 @@ renderHeatmapCalendar(this.container, calendarData)
 dv.span("**💸 Money Spent 💸** (11 intensities instead of 5)")
 
 const calendarData = {
+    year: 2022,
     entries: [],
     colors: {
         oldGithubGreen11:[
@@ -109,6 +111,7 @@ renderHeatmapCalendar(this.container, calendarData)
 dv.span("**💸 Money Spent 💸** (custom scale from 250 to 450)")
 
 const calendarData = {
+    year: 2022,
     entries: [],
     intensityScaleStart: 250,
     intensityScaleEnd: 450
@@ -131,6 +134,7 @@ renderHeatmapCalendar(this.container, calendarData)
 dv.span("**💸 Money Spent 💸** (11 intensities + scale from 150)")
 
 const calendarData = {
+    year: 2022,
     entries: [],
     intensityScaleStart: 150,
     colors: {

--- a/EXAMPLE_VAULT/Overview.md
+++ b/EXAMPLE_VAULT/Overview.md
@@ -16,6 +16,7 @@ see [github repo](https://github.com/Richardsl/heatmap-calendar-obsidian#readme)
 dv.span("**🏋️ Exercise 🏋️**")
 
 const calendarData = {
+    year: 2022,
     colors: {
         red: ["#ff9e82","#ff7b55","#ff4d1a","#e73400","#bd2a00",]
     },
@@ -39,6 +40,7 @@ renderHeatmapCalendar(this.container, calendarData)
 dv.span("**💸 Money Spent 💸**")
 
 const calendarData = {
+    year: 2022,
     entries: [],
 }
 
@@ -60,6 +62,7 @@ renderHeatmapCalendar(this.container, calendarData)
 dv.span("**🍺 Alcohol Consumption 🍺**")
 
 const calendarData = {
+    year: 2022,
     colors: {
         blue: ["#ffdf04","#ffbe04","#ff9a03","#ff6d02","#ff2c01"]
     },
@@ -84,6 +87,7 @@ renderHeatmapCalendar(this.container, calendarData)
 dv.span("**🔗 Writing **- Dont break the chain! 🔗🔗🔗🔗")
 
 const calendarData = {
+    year: 2022,
     colors: {
         white: ["#fff","#fff","#fff","#fff","#fff"],
     },
@@ -112,6 +116,7 @@ renderHeatmapCalendar(this.container, calendarData)
 dv.span("**👫 Social tracker 🧑‍🤝‍🧑**")
 
 const calendarData = {
+    year: 2022,
     colors: {
         blue: ["#8cb9ff","#69a3ff","#428bff","#1872ff","#0058e2"],
         pink: ["#ff96cb","#ff70b8","#ff3a9d","#ee0077","#c30062"],
@@ -144,6 +149,7 @@ const hue1 = 13 //red
 const hue2 = 132 //green
 
 const calendarData = { 
+    year: 2022,
     intensityScaleStart: 1,
     intensityScaleEnd: 9,
     colors: {


### PR DESCRIPTION
The `year` field is not specified in most of the DataViewJS code in the `EXAMPLE_VAULT` folder. And most of the diaries in `daily notes` folder are for the year 2022. This leads to almost blank in the heatmap seen now (2023).

before: 

![image](https://github.com/Richardsl/heatmap-calendar-obsidian/assets/69300707/54385129-ee30-4a75-8a00-273334593f9e)

after:

![image](https://github.com/Richardsl/heatmap-calendar-obsidian/assets/69300707/d383ea51-fc30-4c00-873d-e671c628a362)
