### PR TITLE
Update main.ts to add css selectors of months to individual boxes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -150,6 +150,13 @@ export default class HeatmapCalendar extends Plugin {
                     classNames: [],
                 }
 
+				// determine the date and month for the current box
+				const currentDate = new Date(year, 0, day);
+          		const month = currentDate.toLocaleString('en-us', { month: 'short' });
+
+				// Add the month class name to the box
+          		box.classNames.push(`month-${month.toLowerCase()}`); // e.g., "month-jan", "month-feb", etc.
+
 				if (day === todaysDayNumberLocal && showCurrentDayBorder) box.classNames?.push("today")
 
 				if (mappedEntries[day]) {


### PR DESCRIPTION
Added css selector for each month to the individual boxes in the format of, e.g., ".month-jan, .month-feb, etc."

This allows custom styling of different months. For example the below custom css code will render every second month with a slightly lighter background color.

/* Alters the color of every second month */
.theme-dark .heatmap-calendar-boxes .month-feb.isEmpty, .theme-dark .heatmap-calendar-boxes .month-apr.isEmpty, .theme-dark .heatmap-calendar-boxes .month-jun.isEmpty, .theme-dark .heatmap-calendar-boxes .month-aug.isEmpty, .theme-dark .heatmap-calendar-boxes .month-oct.isEmpty, .theme-dark .heatmap-calendar-boxes .month-dec.isEmpty {
	background: #414141;
}