### PR TITLE
Fix box width for Obsidian 1.6.3 (#128)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -138,7 +138,9 @@
 	flex-grow: 1;
 }
 
-
+.heatmap-calendar-boxes>li {
+  width: 100%;
+}
 
 
 


### PR DESCRIPTION
See issue #128 
Currently the new update breaks the heatmap, where only a thin line (indicating the current day) is visible. The CSS in this PR fixes the issue by setting the width of the boxes to 100% (not entirely sure what was keeping it like that before)