### PR TITLE
Feature: Add an option that allows users to separate months in calendar views.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -11,6 +11,7 @@ interface CalendarData {
 	defaultEntryIntensity: number
 	intensityScaleStart: number
 	intensityScaleEnd: number
+	separateMonths: boolean
 }
 
 interface CalendarSettings extends CalendarData {
@@ -18,6 +19,7 @@ interface CalendarSettings extends CalendarData {
 		[index: string | number]: string[]
 	},
 	weekStartDay: number,
+	separateMonths: boolean,
 }
 
 interface Entry {
@@ -37,6 +39,7 @@ const DEFAULT_SETTINGS: CalendarSettings = {
 	intensityScaleStart: 1,
 	intensityScaleEnd: 5,
 	weekStartDay: 1,
+	separateMonths: false,
 }
 export default class HeatmapCalendar extends Plugin {
 
@@ -112,6 +115,8 @@ export default class HeatmapCalendar extends Plugin {
 			const intensityScaleStart = calendarData.intensityScaleStart ?? minimumIntensity
 			const intensityScaleEnd = calendarData.intensityScaleEnd ?? maximumIntensity
 
+			const separateMonths = calendarData.separateMonths ?? this.settings.separateMonths
+
 			const mappedEntries: Entry[] = []
 			calEntries.forEach(e => {
 				const newEntry = {
@@ -160,6 +165,16 @@ export default class HeatmapCalendar extends Plugin {
 				const currentDate = new Date(year, 0, day);
 				
           		const month = currentDate.toLocaleString('en-us', { month: 'short' });
+
+				// Add padding at the beginning of February to December
+				if (separateMonths && day > 31) {
+					const day_in_month = +currentDate.toLocaleString("en-us", { day: "numeric" });
+					if (day_in_month === 1) {
+						for (let i = 0; i < 7; i++) {
+							boxes.push({ backgroundColor: "transparent" });
+						}
+					}
+				}
 
 				// Add the month class name to the box
           		box.classNames?.push(`month-${month.toLowerCase()}`); // e.g., "month-jan", "month-feb", etc.
@@ -223,6 +238,9 @@ export default class HeatmapCalendar extends Plugin {
 				cls: "heatmap-calendar-boxes",
 				parent: heatmapCalendarGraphDiv,
 			})
+			if (separateMonths) {
+				heatmapCalendarBoxesUl.className += " separate-months";
+			}
 
 			boxes.forEach(e => {
 				const entry = createEl("li", {

--- a/settings.ts
+++ b/settings.ts
@@ -172,6 +172,19 @@ export default class HeatmapCalendarSettingsTab extends PluginSettingTab {
 			)
 	}
 
+	private displayseparateMonthsSettings() {
+		const { containerEl, } = this
+		new Setting(containerEl)
+		  .setName("Separate Months")
+		  .setDesc("Separate months in your calendar views, globally.")
+		  .addToggle(toggle => toggle
+		  .setValue(this.plugin.settings.separateMonths)
+		  .onChange(async (value) => {
+			this.plugin.settings.separateMonths = value;
+			await this.plugin.saveSettings();
+		  }));
+	  }
+
 	display() {
 		const { containerEl, } = this
 
@@ -180,6 +193,8 @@ export default class HeatmapCalendarSettingsTab extends PluginSettingTab {
 		containerEl.createEl("h2", { text: "Heatmap Calendar Settings", })
 
 		this.displayWeekStartDaySettings()
+
+		this.displayseparateMonthsSettings()
 
 		this.displayColorSettings()
 

--- a/styles.css
+++ b/styles.css
@@ -48,6 +48,12 @@
   grid-area: boxes;
 }
 
+.heatmap-calendar-boxes.separate-months {
+  grid-auto-flow: column;
+  grid-template-columns: repeat(64, minmax(0, 1fr));
+  grid-area: boxes;
+}
+
 .heatmap-calendar-days,
 .heatmap-calendar-boxes {
   display: grid;
@@ -92,6 +98,10 @@
 
 .heatmap-calendar-boxes .today {
   border: solid 1px rgb(61, 61, 61);
+}
+
+.theme-dark .heatmap-calendar-boxes .today {
+  border: solid 1px white;
 }
 
 /* Settings */


### PR DESCRIPTION
Hi Richardsl, I added an feature that allows users to separate months.
This option works globally, the effect of this option is similar to LeetCode streak, shown as below:

![image](https://github.com/Richardsl/heatmap-calendar-obsidian/assets/41352700/4a0258ed-3069-42dc-b893-372c7a618582)

By the way, I also fixed a small glitch in this commit.
By adding the following css snippet, "today" is highlighted correctly in Obsdian dark mode.
(Please see the picture above for the effect)

```css
.theme-dark .heatmap-calendar-boxes .today {
  border: solid 1px white;
}
```

Hope you like this new feature and consider merging my code 🙏